### PR TITLE
Improve button focus visibility

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,2 @@
+/* eslint-env browser */
+module.exports = typeof self == 'object' ? self.FormData : window.FormData;


### PR DESCRIPTION
Improves keyboard focus visibility for primary and secondary buttons to meet accessibility contrast and navigation needs. Adds a 2px solid accessible focus outline, refines :focus-visible rules to avoid mouse-triggered outlines, and updates tests to assert the focus styles.