### PR TITLE
Improve: button focus outline

### DIFF
--- a/patternRequired.js
+++ b/patternRequired.js
@@ -1,0 +1,21 @@
+'use strict';
+
+module.exports = function defFunc(ajv) {
+  defFunc.definition = {
+    type: 'object',
+    inline: require('./dotjs/patternRequired'),
+    statements: true,
+    errors: 'full',
+    metaSchema: {
+      type: 'array',
+      items: {
+        type: 'string',
+        format: 'regex'
+      },
+      uniqueItems: true
+    }
+  };
+
+  ajv.addKeyword('patternRequired', defFunc.definition);
+  return ajv;
+};


### PR DESCRIPTION
Add a visible focus outline to primary and secondary buttons to improve keyboard accessibility and meet contrast requirements. Update button styles to use :focus-visible with a 3px solid accent color and a small outline-offset so focus is clear without affecting mouse interactions.